### PR TITLE
feat: Migrate from DALL-E to GPT Image models, fix chat-based image generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,13 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x, 20.x, 22.x]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'

--- a/package-lock.json
+++ b/package-lock.json
@@ -681,9 +681,9 @@
       }
     },
     "node_modules/ansi-escapes": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.1.1.tgz",
-      "integrity": "sha512-Zhl0ErHcSRUaVfGUeUdDuLgpkEo8KIFjB4Y9uAc46ScOpdDiU1Dbyplh7qWJeJ/ZHpbyMSM26+X3BySgnIz40Q==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -772,14 +772,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -860,9 +860,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1062,14 +1062,14 @@
       }
     },
     "node_modules/cli-truncate": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.1.0.tgz",
-      "integrity": "sha512-7JDGG+4Zp0CsknDCedl0DYdaeOhc46QNpXi3NLQblkZpXXgA6LncLDUUyvrjSvZeF3VRQa+KiMGomazQrC1V8g==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "slice-ansi": "^7.1.0",
-        "string-width": "^8.0.0"
+        "slice-ansi": "^8.0.0",
+        "string-width": "^8.2.0"
       },
       "engines": {
         "node": ">=20"
@@ -1198,9 +1198,9 @@
       }
     },
     "node_modules/commander": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.1.tgz",
-      "integrity": "sha512-2JkV3gUZUVrbNA+1sjBOYLsMZ5cEEl8GTFP2a4AVz5hvasAMCQ1D2l2le/cX+pV4N6ZU17zjUahLpIXRrnWL8A==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1828,9 +1828,9 @@
       }
     },
     "node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2178,9 +2178,9 @@
       }
     },
     "node_modules/get-east-asian-width": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
-      "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2269,9 +2269,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2729,19 +2729,18 @@
       }
     },
     "node_modules/lint-staged": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.2.0.tgz",
-      "integrity": "sha512-spdYSOCQ2MdZ9CM1/bu/kDmaYGsrpNOeu1InFFV8uhv14x6YIubGxbCpSmGILFoxkiheNQPDXSg5Sbb5ZuVnug==",
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.4.0.tgz",
+      "integrity": "sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "commander": "14.0.1",
-        "listr2": "9.0.4",
-        "micromatch": "4.0.8",
-        "nano-spawn": "1.0.3",
-        "pidtree": "0.6.0",
-        "string-argv": "0.3.2",
-        "yaml": "2.8.1"
+        "commander": "^14.0.3",
+        "listr2": "^9.0.5",
+        "picomatch": "^4.0.3",
+        "string-argv": "^0.3.2",
+        "tinyexec": "^1.0.4",
+        "yaml": "^2.8.2"
       },
       "bin": {
         "lint-staged": "bin/lint-staged.js"
@@ -2753,10 +2752,23 @@
         "url": "https://opencollective.com/lint-staged"
       }
     },
+    "node_modules/lint-staged/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/listr2": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.4.tgz",
-      "integrity": "sha512-1wd/kpAdKRLwv7/3OKC8zZ5U8e/fajCfWMxacUvB79S5nLrYGPtUI/8chMQhn3LQjsRVErTb9i1ECAwW0ZIHnQ==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
+      "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2788,9 +2800,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -2843,6 +2855,36 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -2891,20 +2933,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/micromatch": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.3",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
       }
     },
     "node_modules/mime-db": {
@@ -3031,9 +3059,9 @@
       }
     },
     "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3077,19 +3105,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
-    },
-    "node_modules/nano-spawn": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/nano-spawn/-/nano-spawn-1.0.3.tgz",
-      "integrity": "sha512-jtpsQDetTnvS2Ts1fiRdci5rx0VYws5jGyC+4IYOTnIQ/wwdf6JdomlHBwqC3bJYOvaKu0C2GSZ1A60anrYpaA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.17"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/nano-spawn?sponsor=1"
-      }
     },
     "node_modules/napi-build-utils": {
       "version": "2.0.0",
@@ -3507,9 +3522,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -3534,9 +3549,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3544,19 +3559,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/pidtree": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
-      "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "pidtree": "bin/pidtree.js"
-      },
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/pino": {
@@ -3797,10 +3799,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
@@ -4107,9 +4112,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.3.tgz",
-      "integrity": "sha512-h+cZ/XXarqDgCjo+YSyQU/ulDEESGGf8AMK9pPNmhNSl/FzPl6L8pMp1leca5z6NuG6tvV/auC8/43tmovowww==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -4335,17 +4340,17 @@
       }
     },
     "node_modules/slice-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
-      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "is-fullwidth-code-point": "^5.0.0"
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
@@ -4412,14 +4417,14 @@
       }
     },
     "node_modules/string-width": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz",
-      "integrity": "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
+      "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "get-east-asian-width": "^1.3.0",
-        "strip-ansi": "^7.1.0"
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
       },
       "engines": {
         "node": ">=20"
@@ -4596,6 +4601,16 @@
       "license": "MIT",
       "dependencies": {
         "real-require": "^0.2.0"
+      }
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/to-regex-range": {
@@ -4925,9 +4940,9 @@
       }
     },
     "node_modules/wrap-ansi/node_modules/emoji-regex": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.5.0.tgz",
-      "integrity": "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
       "license": "MIT"
     },
@@ -4987,9 +5002,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -4997,6 +5012,9 @@
       },
       "engines": {
         "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chimp-gpt",
-  "version": "2.1.6",
+  "version": "2.2.0",
   "description": "A Discord chatbot with revolutionary PocketFlow architecture and OpenAI GPT integration for intelligent conversations.",
   "main": "src/core/combined.js",
   "private": true,
@@ -114,6 +114,6 @@
   "overrides": {
     "undici": "^7.16.0",
     "diff": "^8.0.3",
-    "serialize-javascript": "7.0.3"
+    "serialize-javascript": "^7.0.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/core/combined.js",
   "private": true,
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "node tests/unit/testRunner.js",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "A Discord chatbot with revolutionary PocketFlow architecture and OpenAI GPT integration for intelligent conversations.",
   "main": "src/core/combined.js",
   "private": true,
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "scripts": {
     "test": "node tests/unit/testRunner.js",
     "test:comprehensive": "node tests/comprehensiveTestRunner.js",

--- a/src/commands/modules/image.js
+++ b/src/commands/modules/image.js
@@ -56,9 +56,13 @@ module.exports = {
     .addStringOption(option =>
       option
         .setName('model')
-        .setDescription('Which GPT Image-1 model to use')
+        .setDescription('Which image model to use')
         .setRequired(false)
-        .addChoices({ name: 'GPT Image-1 (Latest model)', value: MODELS.GPT_IMAGE_1 })
+        .addChoices(
+          { name: 'GPT Image 1.5 (Best quality)', value: MODELS.GPT_IMAGE_1_5 },
+          { name: 'GPT Image 1 (Standard)', value: MODELS.GPT_IMAGE_1 },
+          { name: 'GPT Image 1 Mini (Fast & cheap)', value: MODELS.GPT_IMAGE_1_MINI }
+        )
     )
     .addStringOption(option =>
       option

--- a/src/commands/statusReport.js
+++ b/src/commands/statusReport.js
@@ -50,7 +50,7 @@ function detectLLMProviders() {
     },
     imageGeneration: {
       provider: 'OpenAI',
-      model: 'DALL-E 3',
+      model: 'GPT Image 1.5',
       configured: !!process.env.OPENAI_API_KEY && config.ENABLE_IMAGE_GENERATION,
       usage: ['Image Creation', 'Art Generation'],
     },
@@ -343,7 +343,7 @@ async function generateStatusEmbed(client) {
       statsText += `  ├─ OpenAI: ${stats.apiCalls.openai || 0}\n`;
     }
     if (stats.apiCalls && stats.apiCalls.dalle) {
-      statsText += `  ├─ DALL-E: ${stats.apiCalls.dalle || 0}\n`;
+      statsText += `  ├─ Images: ${stats.apiCalls.dalle || 0}\n`;
     }
     const totalErrors = Object.values(stats.errors || {}).reduce((a, b) => a + b, 0);
     const errorRate =

--- a/src/conversation/flow/SimpleChimpGPTFlow.js
+++ b/src/conversation/flow/SimpleChimpGPTFlow.js
@@ -21,6 +21,7 @@ const http = require('http');
 let _weatherService = null;
 let _timeLookup = null;
 let _quakeLookup = null;
+let _imageGeneration = null;
 function getWeatherService() {
   if (!_weatherService) _weatherService = require('../../services/simplified-weather');
   return _weatherService;
@@ -32,6 +33,10 @@ function getTimeLookup() {
 function getQuakeLookup() {
   if (!_quakeLookup) _quakeLookup = require('../../services/quakeLookup');
   return _quakeLookup;
+}
+function getImageGeneration() {
+  if (!_imageGeneration) _imageGeneration = require('../../services/imageGeneration');
+  return _imageGeneration;
 }
 
 const logger = createLogger('SimpleChimpGPTFlow');
@@ -80,13 +85,39 @@ class SimpleChimpGPTFlow {
   async handleUnifiedProcessing(store, data) {
     try {
       const { message } = data;
-      const content = message.content.toLowerCase();
+      // Strip Discord mentions (e.g. "<@1140418202678083625>") from the front of the message
+      // so pattern matching works on the actual text content.
+      const content = message.content
+        .replace(/^<@\d+>\s*/i, '')
+        .trim()
+        .toLowerCase();
 
       logger.debug(`Processing unified request for user ${message.author?.id}`);
 
       // Detect intent and process accordingly
 
-      // Check for knowledge system patterns first (if enabled)
+      // CHECK IMAGE PATTERNS FIRST — before knowledge system.
+      // This prevents "draw a python" from being intercepted as a programming question.
+      const imagePatterns = [
+        // Direct drawing/creation requests — anchor to start of meaningful content
+        /(?:draw|create|generate|make)\s+(?:me\s+|us\s+|a\s+|an\s+|the\s+)?(?:image|picture|photo|artwork|art\s)/i,
+        /^(?:draw|create|generate|make)\s+/i,
+        // "draw a cat", "make me a landscape" — verb + filler + noun
+        /^(?:draw|create|generate|make)\s+(?:me\s+|us\s+)?/i,
+        // Specific image/picture requests
+        /(?:draw|create|generate|make)\s+(?:an?\s+)?(?:image|picture|photo|artwork|art)/i,
+        /(?:image|picture|photo)\s+of/i,
+        /(?:show\s+me|give\s+me)\s+(?:an?\s+)?(?:image|picture|photo)/i,
+        // "I want/need" patterns
+        /^(?:i\s+(?:want|need|would\s+like))\s+(?:a|an|you\s+to\s+draw)/i,
+      ];
+
+      if (imagePatterns.some(pattern => pattern.test(content))) {
+        logger.info('Processing as image generation request');
+        return await this.handleImageGeneration(store, data);
+      }
+
+      // Check for knowledge system patterns (if enabled)
       if (config.ENABLE_KNOWLEDGE_SYSTEM && this.knowledgeFlow) {
         // Skip knowledge system for natural conversation requests
         if (
@@ -157,23 +188,6 @@ class SimpleChimpGPTFlow {
         logger.debug(`No knowledge patterns matched for: "${content.substring(0, 50)}..."`);
       }
 
-      // Check for image generation patterns
-      const imagePatterns = [
-        // Direct drawing/creation requests
-        /^(?:draw|create|generate|make)\s+(?:me\s+|us\s+|a\s+|an\s+|the\s+)?/i,
-        // Specific image/picture requests
-        /(?:draw|create|generate|make)\s+(?:an?\s+)?(?:image|picture|photo|artwork|art)/i,
-        /(?:image|picture|photo)\s+of/i,
-        /(?:show\s+me|give\s+me)\s+(?:an?\s+)?(?:image|picture|photo)/i,
-        // "I want/need" patterns
-        /^(?:i\s+(?:want|need|would\s+like))\s+(?:a|an|you\s+to\s+draw)/i,
-      ];
-
-      if (imagePatterns.some(pattern => pattern.test(content))) {
-        logger.info('Processing as image generation request');
-        return await this.handleImageGeneration(store, data);
-      }
-
       // Check for weather patterns
       const weatherPatterns = [
         /(?:weather|forecast|temperature).*(?:in|for|at|of)\s+(.+)/i,
@@ -227,9 +241,10 @@ class SimpleChimpGPTFlow {
     try {
       const { message } = data;
 
-      // Extract prompt from message content
+      // Extract prompt from message content — strip Discord mentions and command phrases
       const prompt =
         message.content
+          .replace(/^<@\d+>\s*/i, '') // Strip leading Discord mention
           .replace(
             /^(?:draw|create|generate|make)\s+(?:an?\s+)?(?:image|picture|photo|artwork|art)\s+(?:of\s+)?/i,
             ''
@@ -239,66 +254,69 @@ class SimpleChimpGPTFlow {
             /^(?:show\s+me|give\s+me)\s+(?:an?\s+)?(?:image|picture|photo)\s+(?:of\s+)?/i,
             ''
           )
+          .replace(/^(?:draw|create|generate|make)\s+(?:me\s+|us\s+)?/i, '') // "draw me a cat" -> "a cat" -> "cat"
+          .replace(/^(?:a|an|the)\s+/i, '') // Strip leading article
           .trim() || message.content;
 
-      logger.info(`Processing image generation request: ${prompt.substring(0, 50)}...`);
+      logger.info(`Processing image generation request via service: ${prompt.substring(0, 50)}...`);
 
-      // Create OpenAI client using the already-required config and OpenAI class
-      const openaiClient = new OpenAI({ apiKey: config.OPENAI_API_KEY });
-
-      // Track generation timing
-      const imageGenModel = 'chatgpt-image-latest';
-      const imageGenQuality = 'low';
+      // Use the proper imageGeneration service for model remapping, rate limiting, and cost tracking
+      const imageService = getImageGeneration();
       const imageGenStartTime = Date.now();
 
-      // Helper: attempt image generation with a given prompt string
-      const attemptImageGenerate = async attemptPrompt =>
-        openaiClient.images.generate({
-          model: imageGenModel,
-          prompt: attemptPrompt,
-          n: 1,
-          size: '1024x1024',
-          quality: imageGenQuality,
-        });
-
-      // Call OpenAI image API — retry once with creative framing prefix if moderation blocks it
-      let imageResponse;
-      let usedFallbackPrefix = false;
-      try {
-        imageResponse = await attemptImageGenerate(prompt);
-      } catch (firstError) {
-        if (isModerationError(firstError)) {
-          logger.info('Image prompt blocked by moderation, retrying with creative framing prefix');
-          const prefixedPrompt = `Digital artwork, creative illustration: ${prompt}`;
-          imageResponse = await attemptImageGenerate(prefixedPrompt); // may throw — caught by outer catch
-          usedFallbackPrefix = true;
-        } else {
-          throw firstError; // not a moderation error, let outer catch handle it
-        }
-      }
+      const result = await imageService.generateImage(prompt, {
+        model: 'gpt-image-1-mini',
+        size: '1024x1024',
+        quality: 'medium',
+      });
 
       const imageGenElapsedMs = Date.now() - imageGenStartTime;
 
-      // chatgpt-image-latest returns b64_json; fall back to url for older models
-      const imageData = imageResponse.data[0];
-      const imageUrl = imageData.url || null;
+      if (!result.success) {
+        logger.error('Image generation service returned failure:', {
+          error: result.error,
+          prompt: prompt.substring(0, 50),
+        });
 
-      // Extract token/cost info from API response if available
-      const usageData = imageResponse.usage || null;
+        // Map service errors to user-friendly messages
+        let userMessage = "I'm having trouble generating that image right now. Please try again.";
+        if (result.error?.includes('disabled')) {
+          userMessage = '🎨 Image generation is currently disabled. Ask an admin to enable it!';
+        } else if (result.error?.includes('rate limit') || result.error?.includes('Rate limit')) {
+          userMessage =
+            "🐌 Whoa there, speed racer! I'm generating images too fast. Let me catch my breath for a moment and try again in a few seconds!";
+        }
 
-      try {
+        return {
+          success: false,
+          error: result.error,
+          response: userMessage,
+        };
+      }
+
+      // result.images is an array of { url, revisedPrompt } objects
+      const imageResult = result.images[0];
+      const imageUrl = imageResult?.url || null;
+      const revisedPrompt = imageResult?.revisedPrompt || prompt;
+      const estimatedCost = result.estimatedCost;
+
+      // Download or decode the image from the service result
+      let imageBuffer;
+      const fileName = `generated_image_${Date.now()}.png`;
+
+      if (imageResult.b64_json) {
+        imageBuffer = Buffer.from(imageResult.b64_json, 'base64');
+      } else if (imageUrl) {
+        // Download image from URL
         const downloadImage = url => {
-          // https/http are hoisted to module scope — no re-require needed
           return new Promise((resolve, reject) => {
             const client = url.startsWith('https') ? https : http;
-
             client
               .get(url, response => {
                 if (response.statusCode !== 200) {
                   reject(new Error(`Failed to download image: ${response.statusCode}`));
                   return;
                 }
-
                 const chunks = [];
                 response.on('data', chunk => chunks.push(chunk));
                 response.on('end', () => {
@@ -309,78 +327,66 @@ class SimpleChimpGPTFlow {
               .on('error', reject);
           });
         };
+        imageBuffer = await downloadImage(imageUrl);
+      }
 
-        const imageBuffer = imageData.b64_json
-          ? Buffer.from(imageData.b64_json, 'base64')
-          : await downloadImage(imageUrl);
-        const fileName = `generated_image_${Date.now()}.png`;
-
-        // Validate buffer before using it
-        if (!imageBuffer || !Buffer.isBuffer(imageBuffer)) {
-          logger.error('Downloaded image buffer is invalid:', {
-            bufferExists: !!imageBuffer,
-            isBuffer: Buffer.isBuffer(imageBuffer),
-            bufferType: typeof imageBuffer,
-          });
-          throw new Error('Failed to download image - invalid buffer');
-        }
-
-        logger.debug('Image downloaded successfully:', {
-          bufferSize: imageBuffer.length,
-          fileName: fileName,
+      // Validate buffer
+      if (!imageBuffer || !Buffer.isBuffer(imageBuffer)) {
+        logger.error('Image buffer is invalid after service call:', {
+          hasBuffer: !!imageBuffer,
+          isBuffer: Buffer.isBuffer(imageBuffer),
+          hasUrl: !!imageUrl,
         });
 
-        // Save image to PFP rotation if PFPManager is available
-        if (this.pfpManager) {
-          try {
-            const savedPath = await this.pfpManager.addImage(imageBuffer, fileName);
-            logger.info(`Image saved to PFP rotation: ${savedPath}`);
-          } catch (pfpError) {
-            logger.warn('Failed to save image to PFP rotation:', pfpError.message);
-            // Don't fail the whole request if PFP save fails
-          }
+        // Fallback: if we have a URL, return it as a link
+        if (imageUrl) {
+          return {
+            success: true,
+            response: `Your image has been generated! [Click to view](${imageUrl})`,
+            type: 'image',
+            imageUrl: imageUrl,
+            originalPrompt: prompt,
+            imageMetadata: {
+              model: 'gpt-image-1-mini',
+              quality: 'medium',
+              elapsedMs: imageGenElapsedMs,
+              estimatedCost,
+            },
+          };
         }
-
-        return {
-          success: true,
-          response: `Here's your generated image for: "${prompt.substring(0, 100)}${prompt.length > 100 ? '...' : ''}"`,
-          type: 'image',
-          imageUrl: imageUrl,
-          originalPrompt: prompt,
-          attachment: {
-            buffer: imageBuffer,
-            name: fileName,
-          },
-          // Metadata for footer display
-          imageMetadata: {
-            model: imageGenModel,
-            quality: imageGenQuality,
-            elapsedMs: imageGenElapsedMs,
-            usage: usageData,
-            usedFallbackPrefix,
-          },
-        };
-      } catch (downloadError) {
-        logger.warn('Failed to process image data:', downloadError.message);
-
-        // Fallback message if buffer processing fails
-        return {
-          success: true,
-          response: imageUrl
-            ? `Your image has been generated! [Click to view](${imageUrl})`
-            : 'Your image has been generated but could not be retrieved. Please try again.',
-          type: 'image',
-          imageUrl: imageUrl,
-          originalPrompt: prompt,
-          // Metadata for footer display
-          imageMetadata: {
-            model: imageGenModel,
-            quality: imageGenQuality,
-            elapsedMs: imageGenElapsedMs,
-            usage: usageData,
-          },
-        };
+        throw new Error('Failed to process image — no buffer or URL available');
       }
+
+      // Save image to PFP rotation if PFPManager is available
+      if (this.pfpManager) {
+        try {
+          const savedPath = await this.pfpManager.addImage(imageBuffer, fileName);
+          logger.info(`Image saved to PFP rotation: ${savedPath}`);
+        } catch (pfpError) {
+          logger.warn('Failed to save image to PFP rotation:', pfpError.message);
+        }
+      }
+
+      return {
+        success: true,
+        response: `Here's your generated image for: "${prompt.substring(0, 100)}${prompt.length > 100 ? '...' : ''}"`,
+        type: 'image',
+        imageUrl: imageUrl,
+        originalPrompt: prompt,
+        revisedPrompt,
+        attachment: {
+          buffer: imageBuffer,
+          name: fileName,
+        },
+        // Metadata for footer display
+        imageMetadata: {
+          model: 'gpt-image-1-mini',
+          quality: 'medium',
+          elapsedMs: imageGenElapsedMs,
+          estimatedCost,
+          usedService: true,
+        },
+      };
     } catch (error) {
       logger.error('Error generating image:', {
         error: error.message,

--- a/src/conversation/flow/SimpleChimpGPTFlow.js
+++ b/src/conversation/flow/SimpleChimpGPTFlow.js
@@ -98,18 +98,20 @@ class SimpleChimpGPTFlow {
 
       // CHECK IMAGE PATTERNS FIRST — before knowledge system.
       // This prevents "draw a python" from being intercepted as a programming question.
+      // Patterns kept simple to stay under SonarCloud regex complexity threshold (20).
       const imagePatterns = [
-        // Direct drawing/creation requests — anchor to start of meaningful content
-        /(?:draw|create|generate|make)\s+(?:me\s+|us\s+|a\s+|an\s+|the\s+)?(?:image|picture|photo|artwork|art\s)/i,
-        /^(?:draw|create|generate|make)\s+/i,
-        // "draw a cat", "make me a landscape" — verb + filler + noun
-        /^(?:draw|create|generate|make)\s+(?:me\s+|us\s+)?/i,
-        // Specific image/picture requests
-        /(?:draw|create|generate|make)\s+(?:an?\s+)?(?:image|picture|photo|artwork|art)/i,
+        // "draw a cat", "make me a landscape" — verb + filler/pronoun
+        /^(?:draw|create|generate|make)\s+(?:me|us)\s/i,
+        // Bare verb at start — "draw cat", "create something"
+        /^(?:draw|create|generate|make)\s/i,
+        // "create an image", "draw the picture" — verb + optional article + art noun
+        /(?:draw|create|generate|make)\s+(?:an?\s+)?(?:image|picture|photo|art)/i,
+        // "image of a cat", "picture of sunset"
         /(?:image|picture|photo)\s+of/i,
-        /(?:show\s+me|give\s+me)\s+(?:an?\s+)?(?:image|picture|photo)/i,
-        // "I want/need" patterns
-        /^(?:i\s+(?:want|need|would\s+like))\s+(?:a|an|you\s+to\s+draw)/i,
+        // "show me an image", "give me a picture"
+        /(?:show|give)\s+me\s+(?:an?\s+)?(?:image|picture|photo)/i,
+        // "I want a", "I need an image", "I would like you to draw"
+        /^i\s+(?:want|need|would like)\s/i,
       ];
 
       if (imagePatterns.some(pattern => pattern.test(content))) {

--- a/src/core/eventHandlers/interactionEventHandler.js
+++ b/src/core/eventHandlers/interactionEventHandler.js
@@ -80,7 +80,7 @@ class InteractionEventHandler {
 
       await interaction.editReply({ components: [pendingRow] });
 
-      // Generate HD image: chatgpt-image-latest, 1024×1024, high quality
+      // Generate HD image: chatgpt-image-latest (points to best available model), 1024×1024, high quality
       const hdGenStart = Date.now();
       const imageResult = await generateImage(originalPrompt, {
         model: 'chatgpt-image-latest',

--- a/src/core/eventHandlers/messageEventHandler.js
+++ b/src/core/eventHandlers/messageEventHandler.js
@@ -40,12 +40,13 @@ class MessageEventHandler {
 
     // Pre-compiled image-request detection patterns (hoisted from handleMessageCreate hot path
     // so the RegExp objects are created once per handler instance, not on every message).
+    // Patterns kept simple to stay under SonarCloud regex complexity threshold (20).
     this.imageRequestPatterns = [
-      /^(?:<@\d+>\s*)?(?:draw|create|generate|make)\s+(?:me\s+|us\s+|a\s+|an\s+|the\s+)?/i,
-      /(?:draw|create|generate|make)\s+(?:an?\s+)?(?:image|picture|photo|artwork|art)/i,
+      /^(?:<@\d+>\s*)?(?:draw|create|generate|make)\s+/i,
+      /(?:draw|create|generate|make)\s+(?:an?\s+)?(?:image|picture|photo|art)/i,
       /(?:image|picture|photo)\s+of/i,
-      /(?:show\s+me|give\s+me)\s+(?:an?\s+)?(?:image|picture|photo)/i,
-      /^(?:<@\d+>\s*)?(?:i\s+(?:want|need|would\s+like))\s+(?:a|an|you\s+to\s+draw)/i,
+      /(?:show|give)\s+me\s+(?:an?\s+)?(?:image|picture|photo)/i,
+      /^(?:<@\d+>\s*)?i\s+(?:want|need|would like)\s/i,
     ];
 
     // Set up periodic cleanup for enhanced message relationships

--- a/src/core/eventHandlers/messageEventHandler.js
+++ b/src/core/eventHandlers/messageEventHandler.js
@@ -41,11 +41,11 @@ class MessageEventHandler {
     // Pre-compiled image-request detection patterns (hoisted from handleMessageCreate hot path
     // so the RegExp objects are created once per handler instance, not on every message).
     this.imageRequestPatterns = [
-      /^(?:draw|create|generate|make)\s+(?:me\s+|us\s+|a\s+|an\s+|the\s+)?/i,
+      /^(?:<@\d+>\s*)?(?:draw|create|generate|make)\s+(?:me\s+|us\s+|a\s+|an\s+|the\s+)?/i,
       /(?:draw|create|generate|make)\s+(?:an?\s+)?(?:image|picture|photo|artwork|art)/i,
       /(?:image|picture|photo)\s+of/i,
       /(?:show\s+me|give\s+me)\s+(?:an?\s+)?(?:image|picture|photo)/i,
-      /^(?:i\s+(?:want|need|would\s+like))\s+(?:a|an|you\s+to\s+draw)/i,
+      /^(?:<@\d+>\s*)?(?:i\s+(?:want|need|would\s+like))\s+(?:a|an|you\s+to\s+draw)/i,
     ];
 
     // Set up periodic cleanup for enhanced message relationships
@@ -585,6 +585,9 @@ class MessageEventHandler {
                   const metaParts = [`${meta.model} (${meta.quality})`, `${elapsedSec}s`];
                   if (meta.usage && meta.usage.total_tokens) {
                     metaParts.push(`${meta.usage.total_tokens} tokens`);
+                  }
+                  if (meta.estimatedCost) {
+                    metaParts.push(`$${meta.estimatedCost.toFixed(4)}`);
                   }
                   metaLine = `\n_Model: ${metaParts.join(' · ')}_`;
                 }

--- a/src/core/eventHandlers/messageEventHandler.js
+++ b/src/core/eventHandlers/messageEventHandler.js
@@ -567,13 +567,26 @@ class MessageEventHandler {
                 });
 
                 // Build HD upgrade button — prompt encoded in customId (max 100 chars total)
-                const rawPromptForButton = (flowResult.originalPrompt || message.content).substring(
-                  0,
-                  80
-                );
+                // Strip Discord mentions and ensure encoded form fits in 100-char limit
+                const strippedForButton = (flowResult.originalPrompt || message.content)
+                  .replace(/<@\d+>/g, '')
+                  .trim();
+                // Encode and truncate — don't cut mid-%XX, walk back to last complete char
+                let encodedPrompt = encodeURIComponent(strippedForButton);
+                const prefix = 'hd_upgrade:';
+                const maxEncoded = 100 - prefix.length;
+                if (encodedPrompt.length > maxEncoded) {
+                  encodedPrompt = encodedPrompt.substring(0, maxEncoded);
+                  // Avoid cutting mid-%XX: remove trailing incomplete percent-sequence
+                  const trailingPercent = encodedPrompt.match(/%[0-9A-Fa-f]?$/);
+                  if (trailingPercent)
+                    encodedPrompt = encodedPrompt.slice(0, -trailingPercent[0].length);
+                  // Also remove trailing lone % to be safe
+                  if (encodedPrompt.endsWith('%')) encodedPrompt = encodedPrompt.slice(0, -1);
+                }
                 const hdRow = new ActionRowBuilder().addComponents(
                   new ButtonBuilder()
-                    .setCustomId(`hd_upgrade:${encodeURIComponent(rawPromptForButton)}`)
+                    .setCustomId(`${prefix}${encodedPrompt}`)
                     .setLabel('🔍 Upgrade to HD')
                     .setStyle(ButtonStyle.Secondary)
                 );
@@ -621,27 +634,37 @@ class MessageEventHandler {
                   'Discord API call failed - image send/delete error'
                 );
 
-                // Fallback to embed if image send fails
+                // Fallback: try sending as a new file attachment message (not embed — Discord
+                // embeds don't support data: URIs, so we must use the raw buffer)
                 try {
-                  if (flowResult.imageUrl) {
-                    discordLogger.info('Attempting fallback to embed after upload failure');
-                    const imageEmbed = this.createImageEmbed(
-                      flowResult.imageUrl,
-                      flowResult.response
+                  if (flowResult.attachment?.buffer) {
+                    discordLogger.info(
+                      'Attempting fallback: send image as new message with file attachment'
                     );
-
-                    // Thinking message may already be deleted; try edit first, then send new
                     try {
-                      await feedbackMessage.edit({
-                        content: null,
-                        embeds: [imageEmbed],
-                        files: [],
+                      await message.channel.send({
+                        content: flowResult.response || '🎨 Here you go!',
+                        files: [
+                          {
+                            attachment: flowResult.attachment.buffer,
+                            name: flowResult.attachment.name || 'image.png',
+                          },
+                        ],
                       });
-                    } catch {
-                      await message.channel.send({ embeds: [imageEmbed] });
+                    } catch (sendErr) {
+                      discordLogger.error({ err: sendErr }, 'Fallback file send also failed');
+                      const fallbackText = `${flowResult.response}\n\n⚠️ Image generated but could not be displayed.`;
+                      try {
+                        await feedbackMessage.edit({
+                          content: fallbackText,
+                          embeds: [],
+                          files: [],
+                        });
+                      } catch {
+                        await message.channel.send(fallbackText);
+                      }
                     }
-
-                    discordLogger.info('Successfully sent embed fallback');
+                    discordLogger.info('Successfully sent image via fallback file attachment');
                   } else {
                     discordLogger.info('Attempting fallback to text-only response');
                     const fallbackText = `${flowResult.response}\n\n⚠️ Image generated but could not be displayed.`;

--- a/src/core/processors/messageProcessor.js
+++ b/src/core/processors/messageProcessor.js
@@ -234,8 +234,8 @@ class MessageProcessor {
                   },
                   model: {
                     type: 'string',
-                    enum: ['gpt-image-1'],
-                    description: 'The image generation model to use (gpt-image-1 is the default)',
+                    enum: ['gpt-image-1.5', 'gpt-image-1', 'gpt-image-1-mini'],
+                    description: 'The image generation model to use (default: gpt-image-1-mini)',
                   },
                   size: {
                     type: 'string',

--- a/src/core/processors/pocketFlowFunctionProcessor.js
+++ b/src/core/processors/pocketFlowFunctionProcessor.js
@@ -255,7 +255,7 @@ class PocketFlowFunctionProcessor {
    * Returns structured data that the flow can properly process
    */
   async handleImageGeneration(args, _message) {
-    const { prompt, model = 'dall-e-3', size = '1024x1024', enhance = true } = args;
+    const { prompt, model = 'gpt-image-1-mini', size = '1024x1024', enhance = true } = args;
     if (!prompt) {
       throw new Error('Prompt parameter is required for image generation');
     }
@@ -269,15 +269,21 @@ class PocketFlowFunctionProcessor {
       const openaiClient = new OpenAI({ apiKey: config.OPENAI_API_KEY });
 
       // Call OpenAI DALL-E API directly
-      // response_format is only supported by DALL-E 2/3; gpt-image-1/chatgpt-image-latest omit it
-      const gptImage1Models = ['gpt-image-1', 'chatgpt-image-latest'];
+      // response_format: gpt-image-1/1.5/1-mini and chatgpt-image-latest return base64 by default;
+      // DALL-E models (now deprecated) used response_format. All current models omit it.
+      const gptImageModels = [
+        'gpt-image-1',
+        'gpt-image-1.5',
+        'gpt-image-1-mini',
+        'chatgpt-image-latest',
+      ];
       const imageGenParams = {
         model: model,
         prompt: prompt,
         n: 1,
         size: size,
         quality: 'standard',
-        ...(gptImage1Models.includes(model) ? {} : { response_format: 'url' }),
+        ...(gptImageModels.includes(model) ? {} : { response_format: 'url' }),
       };
       const imageResponse = await openaiClient.images.generate(imageGenParams);
 

--- a/src/handlers/imageGenerationHandler.js
+++ b/src/handlers/imageGenerationHandler.js
@@ -247,7 +247,7 @@ async function handleImageGeneration(
       }
 
       // Extract and validate parameters
-      const { prompt, model = 'gpt-image-1', size = '1024x1024', enhance = true } = parameters;
+      const { prompt, model = 'gpt-image-1-mini', size = '1024x1024', enhance = true } = parameters;
 
       if (!prompt || prompt.trim() === '') {
         await feedbackMessage.edit(
@@ -488,7 +488,7 @@ async function handleImageGeneration(
           return;
         }
 
-        const fileExtension = model === 'gpt-image-1' ? 'png' : 'png'; // Default to PNG
+        const fileExtension = 'png'; // All current models return PNG
         const fileName = `generated_image_${Date.now()}.${fileExtension}`;
 
         // Create Discord attachment from processed image

--- a/src/services/imageGeneration.js
+++ b/src/services/imageGeneration.js
@@ -1,6 +1,6 @@
 /**
  * @typedef {Object} ImageGenerationOptions
- * @property {string} [model] - The model to use (gpt-image-1)
+ * @property {string} [model] - The model to use (gpt-image-1.5, gpt-image-1, gpt-image-1-mini)
  * @property {string} [size] - Image size (1024x1024, 1536x1024, 1024x1536, or auto)
  * @property {string} [quality] - Image quality (low, medium, high, auto)
  * @property {string} [format] - Output format (png, jpeg, webp)
@@ -23,8 +23,9 @@
 /**
  * Image Generation Module for ChimpGPT
  *
- * This module provides image generation capabilities using OpenAI's GPT Image-1 model.
- * It allows the bot to generate images based on text prompts and send them to Discord.
+ * This module provides image generation capabilities using OpenAI's GPT Image models
+ * (gpt-image-1.5, gpt-image-1, gpt-image-1-mini). DALL-E 2/3 models are deprecated
+ * and automatically remapped to their current equivalents.
  *
  * @module ImageGeneration
  * @author Brett
@@ -74,10 +75,13 @@ const IMAGE_BREAKER_CONFIG = {
  * @enum {string}
  */
 const MODELS = {
-  DALL_E_3: 'dall-e-3', // Standard DALL-E 3 model
-  DALL_E_2: 'dall-e-2', // Standard DALL-E 2 model
-  GPT_IMAGE_1: 'gpt-image-1', // Legacy name - maps to dall-e-3
-  CHATGPT_IMAGE_LATEST: 'chatgpt-image-latest', // gpt-image-1 API model (HD button uses this)
+  GPT_IMAGE_1: 'gpt-image-1', // Standard model
+  GPT_IMAGE_1_5: 'gpt-image-1.5', // Latest flagship model (replaces dall-e-3)
+  GPT_IMAGE_1_MINI: 'gpt-image-1-mini', // Fast, cost-efficient model (replaces dall-e-2)
+  CHATGPT_IMAGE_LATEST: 'chatgpt-image-latest', // Alias for latest model (HD button uses this)
+  // Legacy aliases — remapped to current models at call time
+  DALL_E_3: 'dall-e-3', // DEPRECATED: remapped to gpt-image-1.5
+  DALL_E_2: 'dall-e-2', // DEPRECATED: remapped to gpt-image-1-mini
 };
 
 /**
@@ -123,7 +127,7 @@ const BACKGROUND = {
 };
 
 /**
- * Generate an image using GPT Image-1.
+ * Generate an image using OpenAI's GPT Image models.
  *
  * Standardized error handling: always returns either an ImageResult or ImageErrorResult.
  * Errors are always logged with stack trace and context.
@@ -174,55 +178,55 @@ async function generateImage(prompt, options = {}) {
     'Image generation configuration check'
   );
   try {
-    // Map legacy model names to current OpenAI API models
-    const requestedModel = options.model || MODELS.GPT_IMAGE_1;
+    // Map model names — resolve legacy/deprecated models to current ones
+    const requestedModel = options.model || MODELS.GPT_IMAGE_1_MINI;
     let actualModel = requestedModel;
 
-    // Map legacy GPT Image 1 to DALL-E 3 (current best model)
-    if (requestedModel === MODELS.GPT_IMAGE_1) {
-      actualModel = MODELS.DALL_E_3;
-      logger.debug('Mapping legacy gpt-image-1 model to dall-e-3');
+    // Remap deprecated DALL-E models to current equivalents
+    if (requestedModel === MODELS.DALL_E_3) {
+      actualModel = MODELS.GPT_IMAGE_1_5;
+      logger.info('Remapping deprecated dall-e-3 to gpt-image-1.5');
+    } else if (requestedModel === MODELS.DALL_E_2) {
+      actualModel = MODELS.GPT_IMAGE_1_MINI;
+      logger.info('Remapping deprecated dall-e-2 to gpt-image-1-mini');
+    } else if (requestedModel === MODELS.GPT_IMAGE_1) {
+      // gpt-image-1 is still valid — use as-is
+      logger.debug('Using gpt-image-1 directly');
     }
 
     // Set default size to square if not specified
     let size = options.size || SIZES.SQUARE;
 
     // Validate the model and size combination based on OpenAI API documentation
-    const validDALLE3Sizes = [SIZES.SQUARE, SIZES.PORTRAIT, SIZES.LANDSCAPE];
-    const validDALLE2Sizes = ['256x256', '512x512', SIZES.SQUARE];
+    // All current models (gpt-image-1, gpt-image-1.5, gpt-image-1-mini, chatgpt-image-latest)
+    // support square, portrait, landscape, and auto sizes
+    const validSizes = [SIZES.SQUARE, SIZES.PORTRAIT, SIZES.LANDSCAPE, SIZES.AUTO];
 
-    if (actualModel === MODELS.DALL_E_3) {
-      if (!validDALLE3Sizes.includes(size)) {
-        logger.warn(`DALL-E 3 does not support ${size} size, falling back to square`);
-        size = SIZES.SQUARE;
-      }
-    } else if (actualModel === MODELS.DALL_E_2) {
-      if (!validDALLE2Sizes.includes(size)) {
-        logger.warn(`DALL-E 2 does not support ${size} size, falling back to square`);
-        size = SIZES.SQUARE;
-      }
+    if (!validSizes.includes(size)) {
+      logger.warn(`Model ${actualModel} does not support ${size} size, falling back to square`);
+      size = SIZES.SQUARE;
     }
 
     // Set quality based on model capabilities
+    // All current models support: low, medium, high, auto
     let quality = options.quality;
-    if (actualModel === MODELS.DALL_E_3) {
-      // DALL-E 3 supports quality parameter
-      quality = quality || 'standard'; // OpenAI standard is 'standard' or 'hd'
-      if (!['standard', 'hd'].includes(quality)) {
-        logger.warn(`Invalid quality ${quality} for DALL-E 3, using 'standard'`);
-        quality = 'standard';
-      }
-    } else if (actualModel === MODELS.CHATGPT_IMAGE_LATEST) {
-      // gpt-image-1 (chatgpt-image-latest) supports 'low', 'medium', 'high', 'auto'
-      quality = quality || 'auto';
-      if (!['low', 'medium', 'high', 'auto'].includes(quality)) {
-        logger.warn(`Invalid quality ${quality} for chatgpt-image-latest, using 'auto'`);
+    if (quality && !['low', 'medium', 'high', 'auto', 'standard', 'hd'].includes(quality)) {
+      logger.warn(`Invalid quality ${quality} for ${actualModel}, using 'auto'`);
+      quality = 'auto';
+    }
+    // Default quality per model
+    if (!quality) {
+      if (actualModel === MODELS.CHATGPT_IMAGE_LATEST || actualModel === MODELS.GPT_IMAGE_1_5) {
+        quality = 'high';
+      } else if (actualModel === MODELS.GPT_IMAGE_1_MINI) {
+        quality = 'medium';
+      } else {
         quality = 'auto';
       }
-    } else {
-      // DALL-E 2 doesn't support quality parameter
-      quality = undefined;
     }
+    // DALL-E legacy quality values (standard/hd) — map to current equivalents
+    if (quality === 'standard') quality = 'medium';
+    if (quality === 'hd') quality = 'high';
 
     // Build the image parameters object according to OpenAI API standards
     const imageParams = {
@@ -232,17 +236,12 @@ async function generateImage(prompt, options = {}) {
       n: 1, // Generate 1 image
     };
 
-    // response_format is only supported by DALL-E 2 and DALL-E 3.
-    // gpt-image-1 / chatgpt-image-latest always returns base64 and does NOT accept this param.
-    if (actualModel === MODELS.DALL_E_2 || actualModel === MODELS.DALL_E_3) {
-      imageParams.response_format = 'b64_json';
-    }
+    // response_format: gpt-image-1/1.5/1-mini and chatgpt-image-latest always return base64
+    // and do NOT accept response_format. Only legacy DALL-E models needed it.
+    // Since all dall-e models are remapped above, no response_format needed.
 
     // Add quality for models that support it
-    if (
-      (actualModel === MODELS.DALL_E_3 || actualModel === MODELS.CHATGPT_IMAGE_LATEST) &&
-      quality
-    ) {
+    if (quality) {
       imageParams.quality = quality;
     }
 
@@ -444,39 +443,108 @@ async function generateImage(prompt, options = {}) {
       'Successfully generated images'
     );
 
-    // Calculate cost based on current OpenAI pricing (December 2024)
+    // Calculate cost based on current OpenAI pricing (April 2026)
     // https://openai.com/pricing
     let estimatedCost = 0;
 
-    if (actualModel === MODELS.DALL_E_3) {
-      // DALL-E 3 pricing (USD per image)
-      const dalle3Costs = {
-        standard: {
-          '1024x1024': 0.04, // $0.040 per image
-          '1024x1792': 0.08, // $0.080 per image
-          '1792x1024': 0.08, // $0.080 per image
+    if (actualModel === MODELS.GPT_IMAGE_1_5 || actualModel === MODELS.CHATGPT_IMAGE_LATEST) {
+      // gpt-image-1.5 pricing (USD per image)
+      // Approximate pricing based on OpenAI rates — update when official pricing is confirmed
+      const gptImage15Costs = {
+        low: {
+          '1024x1024': 0.011,
+          '1536x1024': 0.017,
+          '1024x1536': 0.017,
+          auto: 0.014,
         },
-        hd: {
-          '1024x1024': 0.08, // $0.080 per image
-          '1024x1792': 0.12, // $0.120 per image
-          '1792x1024': 0.12, // $0.120 per image
+        medium: {
+          '1024x1024': 0.042,
+          '1536x1024': 0.063,
+          '1024x1536': 0.063,
+          auto: 0.055,
+        },
+        high: {
+          '1024x1024': 0.167,
+          '1536x1024': 0.25,
+          '1024x1536': 0.25,
+          auto: 0.2,
+        },
+        auto: {
+          '1024x1024': 0.042,
+          '1536x1024': 0.063,
+          '1024x1536': 0.063,
+          auto: 0.055,
         },
       };
 
-      // Convert size format for lookup
       const sizeKey =
-        size === '1536x1024' ? '1792x1024' : size === '1024x1536' ? '1024x1792' : size;
-
-      estimatedCost = dalle3Costs[quality]?.[sizeKey] || dalle3Costs.standard['1024x1024'];
-    } else if (actualModel === MODELS.DALL_E_2) {
-      // DALL-E 2 pricing (USD per image)
-      const dalle2Costs = {
-        '1024x1024': 0.02, // $0.020 per image
-        '512x512': 0.018, // $0.018 per image
-        '256x256': 0.016, // $0.016 per image
+        size === SIZES.PORTRAIT
+          ? '1536x1024'
+          : size === SIZES.LANDSCAPE
+            ? '1024x1536'
+            : size === SIZES.SQUARE
+              ? '1024x1024'
+              : 'auto';
+      estimatedCost =
+        gptImage15Costs[quality]?.[sizeKey] || gptImage15Costs.auto?.['1024x1024'] || 0.042;
+    } else if (actualModel === MODELS.GPT_IMAGE_1) {
+      // gpt-image-1 pricing (USD per image)
+      const gptImage1Costs = {
+        low: {
+          '1024x1024': 0.011,
+          '1536x1024': 0.017,
+          '1024x1536': 0.017,
+          auto: 0.014,
+        },
+        medium: {
+          '1024x1024': 0.042,
+          '1536x1024': 0.063,
+          '1024x1536': 0.063,
+          auto: 0.055,
+        },
+        high: {
+          '1024x1024': 0.167,
+          '1536x1024': 0.25,
+          '1024x1536': 0.25,
+          auto: 0.2,
+        },
+        auto: {
+          '1024x1024': 0.042,
+          '1536x1024': 0.063,
+          '1024x1536': 0.063,
+          auto: 0.055,
+        },
       };
 
-      estimatedCost = dalle2Costs[size] || dalle2Costs['1024x1024'];
+      const sizeKey =
+        size === SIZES.PORTRAIT
+          ? '1536x1024'
+          : size === SIZES.LANDSCAPE
+            ? '1024x1536'
+            : size === SIZES.SQUARE
+              ? '1024x1024'
+              : 'auto';
+      estimatedCost =
+        gptImage1Costs[quality]?.[sizeKey] || gptImage1Costs.auto?.['1024x1024'] || 0.042;
+    } else if (actualModel === MODELS.GPT_IMAGE_1_MINI) {
+      // gpt-image-1-mini pricing (USD per image) — lower cost model
+      const gptImage1MiniCosts = {
+        low: { '1024x1024': 0.002, auto: 0.003 },
+        medium: { '1024x1024': 0.01, auto: 0.012 },
+        high: { '1024x1024': 0.04, auto: 0.048 },
+        auto: { '1024x1024': 0.01, auto: 0.012 },
+      };
+
+      const sizeKey =
+        size === SIZES.PORTRAIT
+          ? '1536x1024'
+          : size === SIZES.LANDSCAPE
+            ? '1024x1536'
+            : size === SIZES.SQUARE
+              ? '1024x1024'
+              : 'auto';
+      estimatedCost =
+        gptImage1MiniCosts[quality]?.[sizeKey] || gptImage1MiniCosts.auto?.['1024x1024'] || 0.01;
     }
 
     // Log the cost calculation

--- a/src/services/imageGeneration.js
+++ b/src/services/imageGeneration.js
@@ -445,106 +445,51 @@ async function generateImage(prompt, options = {}) {
 
     // Calculate cost based on current OpenAI pricing (April 2026)
     // https://openai.com/pricing
-    let estimatedCost = 0;
+    let estimatedCost;
 
-    if (actualModel === MODELS.GPT_IMAGE_1_5 || actualModel === MODELS.CHATGPT_IMAGE_LATEST) {
-      // gpt-image-1.5 pricing (USD per image)
-      // Approximate pricing based on OpenAI rates — update when official pricing is confirmed
-      const gptImage15Costs = {
-        low: {
-          '1024x1024': 0.011,
-          '1536x1024': 0.017,
-          '1024x1536': 0.017,
-          auto: 0.014,
-        },
-        medium: {
-          '1024x1024': 0.042,
-          '1536x1024': 0.063,
-          '1024x1536': 0.063,
-          auto: 0.055,
-        },
-        high: {
-          '1024x1024': 0.167,
-          '1536x1024': 0.25,
-          '1024x1536': 0.25,
-          auto: 0.2,
-        },
-        auto: {
-          '1024x1024': 0.042,
-          '1536x1024': 0.063,
-          '1024x1536': 0.063,
-          auto: 0.055,
-        },
-      };
+    // Map size enum values to cost table keys
+    const sizeToKey = s => {
+      if (s === SIZES.PORTRAIT) return '1536x1024';
+      if (s === SIZES.LANDSCAPE) return '1024x1536';
+      if (s === SIZES.SQUARE) return '1024x1024';
+      return 'auto';
+    };
 
-      const sizeKey =
-        size === SIZES.PORTRAIT
-          ? '1536x1024'
-          : size === SIZES.LANDSCAPE
-            ? '1024x1536'
-            : size === SIZES.SQUARE
-              ? '1024x1024'
-              : 'auto';
+    // gpt-image-1.5 and gpt-image-1 share the same pricing structure
+    const fullSizeCosts = {
+      low: { '1024x1024': 0.011, '1536x1024': 0.017, '1024x1536': 0.017, auto: 0.014 },
+      medium: { '1024x1024': 0.042, '1536x1024': 0.063, '1024x1536': 0.063, auto: 0.055 },
+      high: { '1024x1024': 0.167, '1536x1024': 0.25, '1024x1536': 0.25, auto: 0.2 },
+      auto: { '1024x1024': 0.042, '1536x1024': 0.063, '1024x1536': 0.063, auto: 0.055 },
+    };
+
+    // gpt-image-1-mini only supports square and auto sizes
+    const miniSizeCosts = {
+      low: { '1024x1024': 0.002, auto: 0.003 },
+      medium: { '1024x1024': 0.01, auto: 0.012 },
+      high: { '1024x1024': 0.04, auto: 0.048 },
+      auto: { '1024x1024': 0.01, auto: 0.012 },
+    };
+
+    const COST_TABLES = {
+      [MODELS.GPT_IMAGE_1_5]: fullSizeCosts,
+      [MODELS.CHATGPT_IMAGE_LATEST]: fullSizeCosts,
+      [MODELS.GPT_IMAGE_1]: fullSizeCosts,
+      [MODELS.GPT_IMAGE_1_MINI]: miniSizeCosts,
+    };
+
+    const DEFAULT_COSTS = { fullSize: 0.042, miniSize: 0.01 };
+
+    const costTable = COST_TABLES[actualModel];
+    const key = sizeToKey(size);
+    if (costTable) {
       estimatedCost =
-        gptImage15Costs[quality]?.[sizeKey] || gptImage15Costs.auto?.['1024x1024'] || 0.042;
-    } else if (actualModel === MODELS.GPT_IMAGE_1) {
-      // gpt-image-1 pricing (USD per image)
-      const gptImage1Costs = {
-        low: {
-          '1024x1024': 0.011,
-          '1536x1024': 0.017,
-          '1024x1536': 0.017,
-          auto: 0.014,
-        },
-        medium: {
-          '1024x1024': 0.042,
-          '1536x1024': 0.063,
-          '1024x1536': 0.063,
-          auto: 0.055,
-        },
-        high: {
-          '1024x1024': 0.167,
-          '1536x1024': 0.25,
-          '1024x1536': 0.25,
-          auto: 0.2,
-        },
-        auto: {
-          '1024x1024': 0.042,
-          '1536x1024': 0.063,
-          '1024x1536': 0.063,
-          auto: 0.055,
-        },
-      };
-
-      const sizeKey =
-        size === SIZES.PORTRAIT
-          ? '1536x1024'
-          : size === SIZES.LANDSCAPE
-            ? '1024x1536'
-            : size === SIZES.SQUARE
-              ? '1024x1024'
-              : 'auto';
-      estimatedCost =
-        gptImage1Costs[quality]?.[sizeKey] || gptImage1Costs.auto?.['1024x1024'] || 0.042;
-    } else if (actualModel === MODELS.GPT_IMAGE_1_MINI) {
-      // gpt-image-1-mini pricing (USD per image) — lower cost model
-      const gptImage1MiniCosts = {
-        low: { '1024x1024': 0.002, auto: 0.003 },
-        medium: { '1024x1024': 0.01, auto: 0.012 },
-        high: { '1024x1024': 0.04, auto: 0.048 },
-        auto: { '1024x1024': 0.01, auto: 0.012 },
-      };
-
-      const sizeKey =
-        size === SIZES.PORTRAIT
-          ? '1536x1024'
-          : size === SIZES.LANDSCAPE
-            ? '1024x1536'
-            : size === SIZES.SQUARE
-              ? '1024x1024'
-              : 'auto';
-      estimatedCost =
-        gptImage1MiniCosts[quality]?.[sizeKey] || gptImage1MiniCosts.auto?.['1024x1024'] || 0.01;
+        costTable[quality]?.[key] ||
+        costTable[quality]?.['1024x1024'] ||
+        costTable.auto?.['1024x1024'] ||
+        (costTable === miniSizeCosts ? DEFAULT_COSTS.miniSize : DEFAULT_COSTS.fullSize);
+    } else {
+      estimatedCost = DEFAULT_COSTS.fullSize;
     }
 
     // Log the cost calculation

--- a/src/utils/demoDataGenerator.js
+++ b/src/utils/demoDataGenerator.js
@@ -183,7 +183,7 @@ function generateImageData() {
   const prompt = randomItem(SAMPLE_DATA.imagePrompts);
   return {
     prompt,
-    model: randomInt(0, 1) === 0 ? 'dall-e-2' : 'dall-e-3',
+    model: randomInt(0, 1) === 0 ? 'gpt-image-1.5' : 'gpt-image-1-mini',
     size: randomItem(['256x256', '512x512', '1024x1024']),
     url: `https://example.com/mock-image-${Date.now()}.png`,
     created: Date.now(),

--- a/tests/integration/messageHandlingIntegrationTest.js
+++ b/tests/integration/messageHandlingIntegrationTest.js
@@ -81,7 +81,7 @@ const mockOpenAIClient = {
                     arguments: JSON.stringify({
                       prompt:
                         content.replace(/.*draw|.*image|.*generate/, '').trim() || 'test image',
-                      model: 'gpt-image-1',
+                      model: 'gpt-image-1.5',
                       size: '1024x1024',
                     }),
                   },

--- a/tests/unit/imageGenerationTest.js
+++ b/tests/unit/imageGenerationTest.js
@@ -239,7 +239,7 @@ async function testImageGenerationWorkflow() {
         name: 'Successful image generation',
         parameters: {
           prompt: 'a beautiful sunset over the ocean',
-          model: 'gpt-image-1',
+          model: 'gpt-image-1.5',
           size: '1024x1024',
           enhance: true,
         },
@@ -249,7 +249,7 @@ async function testImageGenerationWorkflow() {
         name: 'Image generation with custom parameters',
         parameters: {
           prompt: 'abstract art with vibrant colors',
-          model: 'gpt-image-1',
+          model: 'gpt-image-1.5',
           size: '512x512',
           enhance: false,
         },
@@ -259,7 +259,7 @@ async function testImageGenerationWorkflow() {
         name: 'Empty prompt handling',
         parameters: {
           prompt: '',
-          model: 'gpt-image-1',
+          model: 'gpt-image-1.5',
           size: '1024x1024',
         },
         expectSuccess: false,

--- a/tests/unit/testRunner.js
+++ b/tests/unit/testRunner.js
@@ -574,7 +574,7 @@ async function runConversationPersistenceTests() {
 /**
  * Run image generation tests
  *
- * Tests the image generation functionality including DALL-E integration, image downloads, and circuit breaker patterns
+ * Tests the image generation functionality including GPT Image model integration, image downloads, and circuit breaker patterns
  *
  * @returns {Promise<Object>} Test results
  */


### PR DESCRIPTION
## Summary

Migrates image generation from deprecated DALL-E 2/3 models to OpenAI's new GPT Image models, and fixes chat-based image generation (e.g. draw me a cat).

## Changes

### DALL-E to GPT Image Migration
- Replace dall-e-2/dall-e-3 with gpt-image-1.5, gpt-image-1, gpt-image-1-mini
- Legacy DALL-E calls auto-remapped at runtime to equivalent GPT Image models
- Default model set to gpt-image-1-mini for faster response times
- Slash command offers 3 model choices
- Cost tracking for gpt-image-1.5 with quality tiers

### Chat Image Generation Fixes
- Strip Discord mention prefix before pattern matching
- Check image patterns BEFORE knowledge patterns (prevents draw a python hijack)
- Route through imageGeneration.js service instead of raw OpenAI API
- Add broader image prompt patterns (create/generate/make)
- Add estimatedCost to chat-generated image metadata footer

### Security Fixes
- serialize-javascript ^7.0.5, undici ^7.16.0, diff ^8.0.3

### Version: 2.2.0