### PR TITLE
fix: correct tokenManager require path in ContextManagerNode

### DIFF
--- a/src/conversation/flow/nodes/ContextManagerNode.js
+++ b/src/conversation/flow/nodes/ContextManagerNode.js
@@ -16,7 +16,7 @@ class ContextManagerNode extends BaseConversationNode {
       ...options,
     });
 
-    const TokenManager = require('../../utils/tokenManager');
+    const TokenManager = require('../../../utils/tokenManager');
     this.tokenConfig = TokenManager.getConfig();
 
     this.config = {
@@ -161,7 +161,7 @@ class ContextManagerNode extends BaseConversationNode {
   }
 
   optimizeContext(messages, options = {}) {
-    const TokenManager = require('../../utils/tokenManager');
+    const TokenManager = require('../../../utils/tokenManager');
     const {
       maxTokens = this.config.defaultMaxTokens,
       emergencyMaxTokens = this.config.emergencyMaxTokens,
@@ -181,12 +181,12 @@ class ContextManagerNode extends BaseConversationNode {
   }
 
   estimateTokenCount(message) {
-    const TokenManager = require('../../utils/tokenManager');
+    const TokenManager = require('../../../utils/tokenManager');
     return TokenManager.estimateMessageTokens(message);
   }
 
   calculateTotalTokens(messages) {
-    const TokenManager = require('../../utils/tokenManager');
+    const TokenManager = require('../../../utils/tokenManager');
     return TokenManager.estimateConversationTokens(messages);
   }
 


### PR DESCRIPTION
## Problem
PocketFlow conversation system fails on startup with:
`Cannot find module '../../utils/tokenManager'`

## Root Cause
`ContextManagerNode.js` uses `../../utils/tokenManager` which resolves to `src/conversation/utils/tokenManager` (nonexistent). The correct path is `../../../utils/tokenManager` resolving to `src/utils/tokenManager`.

## Fix
Corrected all 4 require statements in ContextManagerNode.js from `../../` to `../../../`.

## Testing
- Verified src/utils/tokenManager.js exists and is valid (185 lines)
- Confirmed PocketFlow was falling back gracefully before this fix
- After fix: token estimation and context optimization will work correctly