### PR TITLE
fix: replace deprecated 'ready' event with 'clientReady'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chimp-gpt",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Discord bot with OpenAI — conversations, image generation, weather, search, and Quake stats.",
   "main": "src/core/combined.js",
   "private": true,

--- a/src/core/eventHandlers/clientEventHandler.js
+++ b/src/core/eventHandlers/clientEventHandler.js
@@ -35,7 +35,7 @@ class ClientEventHandler {
   }
 
   setupEventHandlers() {
-    this.client.on('ready', this.handleReady.bind(this));
+    this.client.on('clientReady', this.handleReady.bind(this));
     this.client.on('reconnecting', this.updateDiscordStats.bind(this));
     this.client.on('disconnect', this.updateDiscordStats.bind(this));
     this.client.on('shardResume', this.updateDiscordStats.bind(this));

--- a/src/core/healthCheck.js
+++ b/src/core/healthCheck.js
@@ -391,8 +391,8 @@ function scheduleHealthReports(client) {
     // Client is already ready, start after 10 seconds
     setTimeout(tryStartupMessage, 10000);
   } else {
-    // Wait for the ready event before starting
-    client.once('ready', () => {
+    // Wait for the clientReady event before starting
+    client.once('clientReady', () => {
       logger.info('Client ready event fired, scheduling startup message');
       setTimeout(tryStartupMessage, 10000);
     });

--- a/src/utils/checkBotPermissions.js
+++ b/src/utils/checkBotPermissions.js
@@ -15,7 +15,7 @@ const client = new Client({
   ],
 });
 
-client.on('ready', async () => {
+client.on('clientReady', async () => {
   logger.info(`Logged in as ${client.user.tag}`);
 
   // Get all guilds the bot is in


### PR DESCRIPTION
## Problem
Discord.js v14 emits a DeprecationWarning on startup:
`The ready event has been renamed to clientReady to distinguish it from the gateway READY event and will only emit under that name in v15.`

This will break in v15.

## Fix
Replace all three occurrences of the `ready` event with `clientReady`:
- `clientEventHandler.js`: `.on('ready')` → `.on('clientReady')`
- `healthCheck.js`: `.once('ready')` → `.once('clientReady')`
- `checkBotPermissions.js`: `.on('ready')` → `.on('clientReady')`

## Test Plan
- [x] No remaining `'ready'` event listeners in src/ (grep verified)
- [ ] Bot starts without the DeprecationWarning
- [ ] Startup message still fires correctly after client connects