### PR TITLE
fix: strip base64 image data from function results to prevent 10MB bloat

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chimp-gpt",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Discord bot with OpenAI — conversations, image generation, weather, search, and Quake stats.",
   "main": "src/core/combined.js",
   "private": true,

--- a/src/core/functionResults.js
+++ b/src/core/functionResults.js
@@ -49,6 +49,42 @@ const FILE_CONFIG = {
 // Maximum number of results to store per function type
 const MAX_RESULTS_PER_TYPE = 10;
 
+// Maximum size of any individual string value in a stored result (10KB)
+// Prevents base64 image data and data URIs from bloating the file
+const MAX_STRING_VALUE_LENGTH = 10 * 1024;
+
+/**
+ * Recursively truncate large string values in an object.
+ * Base64 image data and data URIs can be megabytes — this strips them
+ * down to a reasonable size while keeping the rest of the structure intact.
+ *
+ * @param {*} obj - The value to sanitize
+ * @returns {*} The sanitized value
+ */
+function sanitizeEntry(obj) {
+  if (typeof obj === 'string') {
+    if (obj.length > MAX_STRING_VALUE_LENGTH) {
+      // Truncate with a marker so it's clear data was trimmed
+      return (
+        obj.substring(0, MAX_STRING_VALUE_LENGTH) +
+        `...[truncated ${obj.length - MAX_STRING_VALUE_LENGTH} chars]`
+      );
+    }
+    return obj;
+  }
+  if (Array.isArray(obj)) {
+    return obj.map(sanitizeEntry);
+  }
+  if (obj && typeof obj === 'object') {
+    const sanitized = {};
+    for (const key of Object.keys(obj)) {
+      sanitized[key] = sanitizeEntry(obj[key]);
+    }
+    return sanitized;
+  }
+  return obj;
+}
+
 /**
  * Default results object structure
  * @type {Object}
@@ -407,6 +443,12 @@ async function loadResults() {
  */
 async function storeResult(functionType, params, result) {
   try {
+    // Sanitize inputs to prevent large payloads (e.g. base64 images) from
+    // bloating the results file. This is a defense-in-depth measure —
+    // callers should also strip large data, but we guard here too.
+    const safeParams = sanitizeEntry(params);
+    const safeResult = sanitizeEntry(result);
+
     // Load existing results
     const results = await loadResults();
 
@@ -427,8 +469,8 @@ async function storeResult(functionType, params, result) {
       // Add the new result to the beginning of the array
       results.plugins[pluginId].unshift({
         timestamp: new Date().toISOString(),
-        params,
-        result,
+        params: safeParams,
+        result: safeResult,
       });
 
       // Limit the number of results
@@ -445,8 +487,8 @@ async function storeResult(functionType, params, result) {
       // Add the new result to the beginning of the array
       results[functionType].unshift({
         timestamp: new Date().toISOString(),
-        params,
-        result,
+        params: safeParams,
+        result: safeResult,
       });
 
       // Limit the number of results

--- a/src/core/functionResultsOptimizer.js
+++ b/src/core/functionResultsOptimizer.js
@@ -25,6 +25,37 @@ const MAX_RESULTS_PER_TYPE = 10;
 const MAX_RESULTS_AGE_DAYS = 7; // Remove results older than 7 days
 const SAVE_INTERVAL_MS = 5 * 60 * 1000; // Save every 5 minutes
 const MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024; // 5MB limit for results file
+const MAX_STRING_VALUE_LENGTH = 10 * 1024; // 10KB max for any string value
+
+/**
+ * Recursively truncate large string values in an object.
+ * Prevents base64 image data and data URIs from bloating the cache.
+ *
+ * @param {*} obj - The value to sanitize
+ * @returns {*} The sanitized value
+ */
+function sanitizeEntry(obj) {
+  if (typeof obj === 'string') {
+    if (obj.length > MAX_STRING_VALUE_LENGTH) {
+      return (
+        obj.substring(0, MAX_STRING_VALUE_LENGTH) +
+        `...[truncated ${obj.length - MAX_STRING_VALUE_LENGTH} chars]`
+      );
+    }
+    return obj;
+  }
+  if (Array.isArray(obj)) {
+    return obj.map(sanitizeEntry);
+  }
+  if (obj && typeof obj === 'object') {
+    const sanitized = {};
+    for (const key of Object.keys(obj)) {
+      sanitized[key] = sanitizeEntry(obj[key]);
+    }
+    return sanitized;
+  }
+  return obj;
+}
 
 // In-memory cache of results
 let resultsCache = null;
@@ -279,8 +310,8 @@ async function storeResult(functionType, params, result) {
 
     const resultEntry = {
       timestamp: new Date().toISOString(),
-      params,
-      result,
+      params: sanitizeEntry(params),
+      result: sanitizeEntry(result),
     };
 
     // Handle plugin results

--- a/src/services/imageGeneration.js
+++ b/src/services/imageGeneration.js
@@ -616,9 +616,15 @@ async function generateImage(prompt, options = {}) {
     }
 
     // Store the function result for the status page
+    // Strip base64 image data to prevent unbounded file growth
+    const lightweightImages = images.map(img => ({
+      revisedPrompt: img.revisedPrompt,
+      // Only keep URL if it's a real URL (not a data URI with embedded base64)
+      ...(img.url && !img.url.startsWith('data:') ? { url: img.url } : {}),
+    }));
     const result = {
       success: true,
-      images: images,
+      images: lightweightImages,
       estimatedCost: estimatedCost,
     };
 


### PR DESCRIPTION
## Problem
`function-results.json` grew to 11MB because gptimage results stored full base64-encoded image data — both the `b64_json` field (~3MB each) and the `url` field containing `data:` URIs (~3MB each). Just 2 image generations produced 10MB of stored data, triggering the startup warning `Function results file exceeds 5MB, cleaning up`.

## Root Cause
`imageGeneration.js` passed the raw `images` array (including base64 data) directly to `functionResults.storeResult()`. The storage layer had no size protection — it only limited entry count (10 per type), not entry size.

## Fix (three layers of defense)

1. **imageGeneration.js** — Strip `b64_json` and data: URIs before storing. Only keep `revisedPrompt` and real URLs as metadata for the status page.

2. **functionResults.js** — Add `sanitizeEntry()` that recursively truncates any string > 10KB before storage. Defense-in-depth: even if a caller forgets to strip, bloat is impossible.

3. **functionResultsOptimizer.js** — Same `sanitizeEntry()` guard in the cached write path.

Also reset the bloated `data/function-results.json` on the server (11MB → 145 bytes).

## Test Plan
- [x] Lint and prettier pass
- [x] No remaining base64 data in stored results after fix
- [ ] Bot starts without the 5MB warning
- [ ] New image generation stores lightweight results only