### PR TITLE
fix: deduplicate sanitizeEntry to resolve SonarCloud quality gate failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
           cp .env.example .env
           echo "DISCORD_TOKEN=dummy_token" >> .env
           echo "OPENAI_API_KEY=dummy_key" >> .env
+          echo "CHANNEL_ID=123456789" >> .env
 
       - name: Lint
         run: npm run lint

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -35,6 +35,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Create .env file
+        run: |
+          cp .env.example .env
+          echo "DISCORD_TOKEN=dummy_token" >> .env
+          echo "OPENAI_API_KEY=dummy_key" >> .env
+          echo "CHANNEL_ID=123456789" >> .env
+          
       - name: Run security audit
         id: audit
         run: |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chimp-gpt",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Discord bot with OpenAI — conversations, image generation, weather, search, and Quake stats.",
   "main": "src/core/combined.js",
   "private": true,

--- a/src/core/functionResults.js
+++ b/src/core/functionResults.js
@@ -666,4 +666,6 @@ module.exports = {
   clearResults,
   repairResultsFile,
   DEFAULT_RESULTS,
+  sanitizeEntry,
+  MAX_STRING_VALUE_LENGTH,
 };

--- a/src/core/functionResultsOptimizer.js
+++ b/src/core/functionResultsOptimizer.js
@@ -15,6 +15,7 @@
 const fs = require('fs').promises;
 const path = require('path');
 const { createLogger } = require('./logger');
+const { sanitizeEntry, MAX_STRING_VALUE_LENGTH } = require('./functionResults');
 const logger = createLogger('functionOptimizer');
 
 // Path to the function results file
@@ -25,37 +26,6 @@ const MAX_RESULTS_PER_TYPE = 10;
 const MAX_RESULTS_AGE_DAYS = 7; // Remove results older than 7 days
 const SAVE_INTERVAL_MS = 5 * 60 * 1000; // Save every 5 minutes
 const MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024; // 5MB limit for results file
-const MAX_STRING_VALUE_LENGTH = 10 * 1024; // 10KB max for any string value
-
-/**
- * Recursively truncate large string values in an object.
- * Prevents base64 image data and data URIs from bloating the cache.
- *
- * @param {*} obj - The value to sanitize
- * @returns {*} The sanitized value
- */
-function sanitizeEntry(obj) {
-  if (typeof obj === 'string') {
-    if (obj.length > MAX_STRING_VALUE_LENGTH) {
-      return (
-        obj.substring(0, MAX_STRING_VALUE_LENGTH) +
-        `...[truncated ${obj.length - MAX_STRING_VALUE_LENGTH} chars]`
-      );
-    }
-    return obj;
-  }
-  if (Array.isArray(obj)) {
-    return obj.map(sanitizeEntry);
-  }
-  if (obj && typeof obj === 'object') {
-    const sanitized = {};
-    for (const key of Object.keys(obj)) {
-      sanitized[key] = sanitizeEntry(obj[key]);
-    }
-    return sanitized;
-  }
-  return obj;
-}
 
 // In-memory cache of results
 let resultsCache = null;


### PR DESCRIPTION
## Problem

PR #15 introduced a `sanitizeEntry()` function and `MAX_STRING_VALUE_LENGTH` constant as defense-in-depth against base64 image bloat. The same 23 lines were copy-pasted into both `functionResults.js` and `functionResultsOptimizer.js`, causing SonarCloud to flag **73.6% duplication on new code** (threshold ≤ 3%).

## Fix

- **Export** `sanitizeEntry` and `MAX_STRING_VALUE_LENGTH` from `functionResults.js`
- **Import** them in `functionResultsOptimizer.js` — remove the local duplicate (31 lines deleted, 1 import line added)
- **Bump** version to 2.2.3

No circular dependency risk: `functionResultsOptimizer` doesn't export anything that `functionResults` imports.

## Test plan
- [x] Lint passes (0 errors)
- [x] Tests pass
- [ ] SonarCloud Quality Gate passes on this PR