### PR TITLE
fix: skip postinstall in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,10 @@ WORKDIR /usr/src/app
 
 # Install dependencies
 COPY package*.json ./
-# Skip prepare script which tries to install husky
-RUN npm pkg delete scripts.prepare && npm ci --omit=dev
+# Skip prepare (husky) and postinstall (security:auto) scripts.
+# postinstall runs scripts/security-check.js which isn't available yet
+# (app source is copied in the next step) and isn't needed in the image.
+RUN npm pkg delete scripts.prepare scripts.postinstall && npm ci --omit=dev
 
 # Copy app source
 COPY . .

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chimp-gpt",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "description": "Discord bot with OpenAI — conversations, image generation, weather, search, and Quake stats.",
   "main": "src/core/combined.js",
   "private": true,


### PR DESCRIPTION
The Docker build fails because `npm ci` triggers the postinstall script (`npm run security:auto`), which runs `scripts/security-check.js` — but the scripts/ directory hasn't been COPY'd into the image yet at that point.

Fix: also delete `scripts.postinstall` alongside `scripts.prepare` before running `npm ci` in the Dockerfile. The security check is not needed in the Docker image — it runs in CI before the image is built.

Bumps version 2.2.6 → 2.2.7.

Fixes the failed build: https://github.com/f0rky/Chimp-GPT/actions/runs/24541779003