### PR TITLE
fix: upgrade uuid to v14, fix follow-redirects vuln (v2.2.9)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chimp-gpt",
-  "version": "2.1.6",
+  "version": "2.2.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chimp-gpt",
-      "version": "2.1.6",
+      "version": "2.2.9",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -23,7 +23,7 @@
         "playwright-extra": "^4.3.6",
         "playwright-extra-plugin-stealth": "^0.0.1",
         "rate-limiter-flexible": "^7.1.0",
-        "uuid": "^11.1.0"
+        "uuid": "^14.0.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.1",
@@ -41,6 +41,9 @@
         "prettier": "^3.5.3",
         "sinon": "^21.0.1",
         "sinon-chai": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@discordjs/builders": {
@@ -2027,9 +2030,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -4762,16 +4765,16 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/esm/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chimp-gpt",
-  "version": "2.2.8",
+  "version": "2.2.9",
   "description": "Discord bot with OpenAI — conversations, image generation, weather, search, and Quake stats.",
   "main": "src/core/combined.js",
   "private": true,
@@ -95,7 +95,7 @@
     "playwright-extra": "^4.3.6",
     "playwright-extra-plugin-stealth": "^0.0.1",
     "rate-limiter-flexible": "^7.1.0",
-    "uuid": "^11.1.0"
+    "uuid": "^14.0.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",


### PR DESCRIPTION
## Summary

Clears all npm audit vulnerabilities — was blocked on `uuid` because the security workflow assumed `--force` was needed, but uuid v14 actually ships a CJS build so `require('uuid')` keeps working with zero code changes.

## Changes

- **uuid** `^11.1.0` → `^14.0.0` — fixes [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq) (buffer bounds check in v3/v5/v6)
- **follow-redirects** bumped via `npm audit fix` — fixes [GHSA-r4q5-vmmm-2653](https://github.com/advisories/GHSA-r4q5-vmmm-2653) (auth header leak on cross-domain redirect) — this one was hiding behind the uuid vuln
- **Version bump** 2.2.8 → 2.2.9

## Verification

```
npm audit → found 0 vulnerabilities
require('./src/middleware/circuitBreaker.js') → loads OK
```

No code changes needed — uuid v14 node export is CJS-compatible.